### PR TITLE
add editor note

### DIFF
--- a/draft-tt-netmod-yang-config-templates.md
+++ b/draft-tt-netmod-yang-config-templates.md
@@ -339,6 +339,8 @@ three cases:
    empty (i.e. a list of templates to apply to the node).  The apply-
    templates metadata is changed to match the value in the request.
 
+> Editor's Note: What if a specific node has some templates applied, and another \<edit-config\> provides another set of values of apply-template? It is a merge or full replace? Should this whole solution be combined with NETCONF "operation" attribute?
+
 *  The apply-templates attribute is specified and the value is the
    empty string.  The apply-templates metadata is removed and thus no
    templates are applied to the node.


### PR DESCRIPTION
I was trying to resolve the comment (If we remove a template application does this mean over time you end up with apply-templates="" on all nodes? Or should you servers remove this metadata when it equals ""?) from James Cumming at IETF 123, and found that the draft has already stated this:
  > The apply-templates attribute is specified and the value is the
  > empty string.  The apply-templates metadata is removed and thus no
  > templates are applied to the node.

So it looks to me nothing else needs to be added. But I think we may need further discussion on the existing solution in the draft, and consider whether it should be combined with the "operation" attribute (see https://datatracker.ietf.org/doc/html/rfc6241#section-7.2) defined in 6241. 